### PR TITLE
[Issue-5] Patch Creation/Application Toasty

### DIFF
--- a/src/LitePatch/LitePatch.Main/MainWindow.xaml.cs
+++ b/src/LitePatch/LitePatch.Main/MainWindow.xaml.cs
@@ -3,6 +3,7 @@ using LitePatch.Services.Interfaces;
 using LitePatch.Services.Repo;
 using LitePatch.Services.Services;
 using Microsoft.Extensions.DependencyInjection;
+using MudBlazor;
 using MudBlazor.Services;
 
 namespace LitePatch;
@@ -15,18 +16,22 @@ public partial class MainWindow : Window
     public MainWindow()
     {
         InitializeComponent();
-        
+
         var collection = new ServiceCollection();
         collection.AddWpfBlazorWebView();
         collection.AddBlazorWebViewDeveloperTools();
-        collection.AddMudServices();
+        collection.AddMudServices(config =>
+        {
+            config.SnackbarConfiguration.ShowCloseIcon = true;
+            config.SnackbarConfiguration.PositionClass = Defaults.Classes.Position.BottomLeft;
+        });
 
         collection.AddSingleton<ISettingsRepository, SettingsRepository>();
         collection.AddSingleton<IPatchRepository, PatchRepository>();
         collection.AddSingleton<ISettingsService, SettingsService>();
         collection.AddSingleton<IGitInfoService, GitInfoService>();
         collection.AddSingleton<IGitPatchService, GitPatchService>();
-        
+
         Resources.Add("services", collection.BuildServiceProvider());
     }
 }

--- a/src/LitePatch/LitePatch.Services/Interfaces/IGitPatchService.cs
+++ b/src/LitePatch/LitePatch.Services/Interfaces/IGitPatchService.cs
@@ -5,12 +5,12 @@ namespace LitePatch.Services.Interfaces;
 public interface IGitPatchService
 {
     public List<PatchInfo> PatchList { get; set; }
-    
+
     public string PatchFolderPath { get; set; }
-    
-    public void ExportPatch(string sha, string commitName);
-    
-    public void ApplyPatch(PatchInfo patch);
-    
+
+    public bool ExportPatch(string sha, string commitName);
+
+    public bool ApplyPatch(PatchInfo patch);
+
     public bool LoadPatchesFromFolder();
 }

--- a/src/LitePatch/LitePatch.Services/Interfaces/IPatchRepository.cs
+++ b/src/LitePatch/LitePatch.Services/Interfaces/IPatchRepository.cs
@@ -4,10 +4,9 @@ namespace LitePatch.Services.Interfaces;
 
 public interface IPatchRepository
 {
-    public PatchInfo CreatePatchFile(string sha, string commitName, int counter);
-    
-    public List<PatchInfo> LoadPatchesToList(string path);
-    
-    public bool ApplyPatchFile(PatchInfo patchInfo);
+    public bool CreatePatchFile(string sha, string commitName, int counter);
 
+    public List<PatchInfo> LoadPatchesToList(string path);
+
+    public bool ApplyPatchFile(PatchInfo patchInfo);
 }

--- a/src/LitePatch/LitePatch.Services/Services/GitPatchService.cs
+++ b/src/LitePatch/LitePatch.Services/Services/GitPatchService.cs
@@ -8,18 +8,28 @@ public class GitPatchService(IPatchRepository patchRepository) : IGitPatchServic
 {
     private int _counter = 1;
 
-    public List<PatchInfo> PatchList { get; set; }  = new();
+    public List<PatchInfo> PatchList { get; set; } = new();
     public string PatchFolderPath { get; set; } = string.Empty;
 
-    public void ExportPatch(string sha, string commitName)
+    public bool ExportPatch(string sha, string commitName)
     {
-        patchRepository.CreatePatchFile(sha, commitName, _counter);
-        _counter++;
+        if (patchRepository.CreatePatchFile(sha, commitName, _counter))
+        {
+            _counter++;
+            return true;
+        }
+
+        return false;
     }
-    
-    public void ApplyPatch(PatchInfo patch)
+
+    public bool ApplyPatch(PatchInfo patch)
     {
-        patchRepository.ApplyPatchFile(patch);
+        if (patchRepository.ApplyPatchFile(patch))
+        {
+            return true;
+        }
+
+        return false;
     }
 
     public bool LoadPatchesFromFolder()
@@ -37,5 +47,4 @@ public class GitPatchService(IPatchRepository patchRepository) : IGitPatchServic
 
         return true;
     }
-
 }

--- a/src/LitePatch/LitePatch.Ui/Components/Pages/PatchApply.razor
+++ b/src/LitePatch/LitePatch.Ui/Components/Pages/PatchApply.razor
@@ -2,36 +2,37 @@
 @using LitePatch.Services.Interfaces
 @using LitePatch.Ui.Components.Controls
 @using LitePatch.Services.Models
+@inject ISnackbar Snackbar
 @inject IGitPatchService GitPatchService
 
 <MudPaper Elevation="2">
     <MudStack>
-    <MudText>Apply patches from:</MudText>
-        <FolderPicker 
-            Label="Patch Folder" 
-            FolderPath="@GitPatchService.PatchFolderPath" 
+        <MudText>Apply patches from:</MudText>
+        <FolderPicker
+            Label="Patch Folder"
+            FolderPath="@GitPatchService.PatchFolderPath"
             FolderPathChanged="v => SetPatchFolderPath(v)"/>
     </MudStack>
 </MudPaper>
 
-<MudPaper Class="mt-1"  Elevation="2">
-        <MudText>Apply a patch by clicking the symbol next to the patch name </MudText>
-        <MudTable Items="@GitPatchService.PatchList" Dense="true" Elevation="0">
-            <HeaderContent>
-                <MudTh>Patch Name</MudTh>
-                <MudTh>Actions</MudTh>
-            </HeaderContent>
-            <RowTemplate>
-                <MudTd DataLabel="CommitName">@context.PatchName</MudTd>
-                <MudTd DataLabel="Actions">
-                    <CellTemplate>
-                        <MudIconButton Disabled="context.HasBeenApplied" 
-                                       Icon="@Icons.Material.Filled.KeyboardDoubleArrowLeft" 
-                                       @onclick="() => ApplyPatch(context)"/>
-                    </CellTemplate>
-                </MudTd>
-            </RowTemplate>
-        </MudTable>
+<MudPaper Class="mt-1" Elevation="2">
+    <MudText>Apply a patch by clicking the symbol next to the patch name </MudText>
+    <MudTable Items="@GitPatchService.PatchList" Dense="true" Elevation="0">
+        <HeaderContent>
+            <MudTh>Patch Name</MudTh>
+            <MudTh>Actions</MudTh>
+        </HeaderContent>
+        <RowTemplate>
+            <MudTd DataLabel="CommitName">@context.PatchName</MudTd>
+            <MudTd DataLabel="Actions">
+                <CellTemplate>
+                    <MudIconButton Disabled="context.HasBeenApplied"
+                                   Icon="@Icons.Material.Filled.KeyboardDoubleArrowLeft"
+                                   @onclick="() => ApplyPatch(context)"/>
+                </CellTemplate>
+            </MudTd>
+        </RowTemplate>
+    </MudTable>
 </MudPaper>
 
 @code {
@@ -40,12 +41,15 @@
     {
         GitPatchService.PatchFolderPath = path;
         GitPatchService.LoadPatchesFromFolder();
-
     }
-    
+
     private void ApplyPatch(PatchInfo patch)
     {
-        GitPatchService.ApplyPatch(patch);
+        if (!GitPatchService.ApplyPatch(patch))
+        {
+            Snackbar.Add("Patch could not be applied", Severity.Error);
+        }
+        Snackbar.Add("Patch applied Successfully", Severity.Success);
     }
-    
+
 }

--- a/src/LitePatch/LitePatch.Ui/Components/Pages/PatchCreate.razor
+++ b/src/LitePatch/LitePatch.Ui/Components/Pages/PatchCreate.razor
@@ -1,7 +1,7 @@
 ﻿@page "/PatchCreate"
 @using LitePatch.Services.Interfaces
 @using LibGit2Sharp
-@using LitePatch.Ui.Components.Controls
+@inject ISnackbar Snackbar
 @inject IGitInfoService GitInfoService
 @inject IGitPatchService GitPatchService
 
@@ -27,6 +27,7 @@
 
 
 @code {
+
     protected override void OnInitialized()
     {
         GitInfoService.InfoChanged += (_, _) => InvokeAsync(StateHasChanged);
@@ -35,9 +36,12 @@
     private void CreatePatch(Commit commit)
     {
         var sha = commit.Sha;
-        GitPatchService.ExportPatch(sha, commit.Message);
+        
+        if (!GitPatchService.ExportPatch(sha, commit.Message))
+        {
+            Snackbar.Add("Patch could not be created", Severity.Error);
+        }
+        Snackbar.Add($"Patch created successfully", Severity.Success);
     }
     
-    
-
 }


### PR DESCRIPTION
If patch creation/application a green snackbar with a success message appears. 
If creation/application fails a red snackbar with an error message appears.

Q:
Settings for snackbar in mainwindow codebehind okay? 
Error should probably be more expressive and give an actual reason. Any suggestions? 